### PR TITLE
Make pairs, don't whine

### DIFF
--- a/align-cljlet.el
+++ b/align-cljlet.el
@@ -221,8 +221,8 @@
       (while (progn
                (acl-goto-next-pair))
         (if (= current-line (line-number-at-pos))
-            (error "multiple pairs on one line")
-          (setq current-line (line-number-at-pos))))))
+            (insert "\n"))
+        (setq current-line (line-number-at-pos)))))
   t)
 
 (defun acl-respace-single-let (max-width)


### PR DESCRIPTION
Rather than complain that there are several pairs on a single line,
instead just insert a line break between consecutive pairs and move on.
